### PR TITLE
Update deployment.yml

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -11,14 +11,14 @@ jobs:
    schedule: '0 */8 * * *' # Define when this job should run, using cron format. This example will run every day at 12:00pm (according to your warehouse timezone). For help with cron formatting, visit https://crontab.guru/.
    steps:
      - name: run models tusk # Give each step in your job a name. This will enable you to track the steps in the logs.
-       command: dbt run --vars '{"shopify_schema":"tusk_shopify"}' #dbt run # Enter the dbt command that should run in this step. This example will run all your models. For a list of available commands visit https://docs.getdbt.com/reference/model-selection-syntax/.
+       command: dbt run --vars '{shopify_schema: tusk_shopify}' #dbt run # Enter the dbt command that should run in this step. This example will run all your models. For a list of available commands visit https://docs.getdbt.com/reference/model-selection-syntax/.
      - name: test models tusk
-       command: dbt test --vars '{"shopify_schema":"tusk_shopify"}' #This example will run all your tests.
+       command: dbt test --vars '{shopify_schema: tusk_shopify}' #This example will run all your tests.
  - name: every8hoursprive
    targetName: devprive # The name of the target that will be used when running the job. If it's not specified, the target will be named 'prod'.
    schedule: '0 */8 * * *' # Define when this job should run, using cron format. This example will run every day at 12:00pm (according to your warehouse timezone). For help with cron formatting, visit https://crontab.guru/.
    steps:
      - name: run models prive # Give each step in your job a name. This will enable you to track the steps in the logs.
-       command: dbt run --vars '{"shopify_schema":"prive_shopify"}' #dbt run # Enter the dbt command that should run in this step. This example will run all your models. For a list of available commands visit https://docs.getdbt.com/reference/model-selection-syntax/.
+       command: dbt run --vars '{shopify_schema: prive_shopify}' #dbt run # Enter the dbt command that should run in this step. This example will run all your models. For a list of available commands visit https://docs.getdbt.com/reference/model-selection-syntax/.
      - name: test models prive
-       command: dbt test --vars '{"shopify_schema":"prive_shopify"}' #This example will run all your tests.
+       command: dbt test --vars '{shopify_schema :prive_shopify}' #This example will run all your tests.


### PR DESCRIPTION
@nevinjethmalani After reading your email it seems that the actual declaration of the schemas in the `dbt run` command is not working as intended. 

The `tusk` run is working properly because you have set the default schema to be `tusk_shopify` if no schema is provided. 
https://github.com/nevinjethmalani/shopify_fivetran_dbt_tusk/blob/672bb1ed21c99e7b16dc65498fbbc185dc8d7702/dbt_project.yml#L35

Therefore, I imagine the declaration of the shopify_schema variable to be `prive_shopify` in the dbt run command is not be captured by dbt. This PR removes the quotes in your run logic as that may be what is causing dbt to not recognize the variable you are trying to set in the run command. Let me know if this works!